### PR TITLE
fix: macOS tests & use LIBS instead of LDFLAGS

### DIFF
--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -31,7 +31,7 @@ class UbuntuPythonBuilder : NixPythonBuilder {
         $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
 
         ### To build Python with SO, passing relative path W.r.t to the binary location.
-        $env:LDFLAGS="-Wl,-rpath='`$`$ORIGIN/../lib'"
+        $env:LIBS = "-Wl,--enable-new-dtags,-rpath='`$`$ORIGIN/../lib'"
         $configureString = "./configure"
         $configureString += " --prefix=$pythonBinariesLocation"
         $configureString += " --enable-shared"
@@ -43,7 +43,7 @@ class UbuntuPythonBuilder : NixPythonBuilder {
 
         Write-Host "The passed configure options are: "
         Write-Host $configureString
-        Write-Host "LDFLAGS: $env:LDFLAGS"
+        Write-Host "LIBS: $env:LIBS"
 
         Execute-Command -Command $configureString
     }

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -94,7 +94,9 @@ Describe "Tests" {
         It "Check if shared libraries are linked correctly" {
             "bash ./sources/psutil-install-test.sh" | Should -ReturnZeroExitCode
         }
+    }
 
+    if (($Platform -match "ubuntu") -or ($Platform -match "linux")) {
         It "Relocatable Python" {
             $semversion = [semver] $Version
             $pyfilename = "python$($semversion.Major).$($semversion.Minor)"


### PR DESCRIPTION
A couple fixes for https://github.com/actions/python-versions/pull/275
Build (rebased on upstream main): https://github.com/mayeut/python-versions/actions/runs/11767364478
